### PR TITLE
Change swag link to pop

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
       <li><a href="https://system76.com/laptops">Laptops</a></li>
       <li><a href="https://system76.com/desktops">Desktops</a></li>
       <li><a href="https://system76.com/servers">Servers</a></li>
-      <li><a href="https://system76.com/swag">Swag</a></li>
+      <li><a href="https://system76.com/pop">Pop!_OS</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
The main site was updated to have a Pop!_OS link instead of swag. This updates Pop!_Docs to match.